### PR TITLE
Added curl package to enable healthcheck to succeed

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
     sudo \
     vim \
     wget \
+    curl \
     telnet \
     ssl-cert \
     nginx \


### PR DESCRIPTION
Currently the container does not get into healthy status due to the healthcheck failing, which relies on the presence of `curl`.