### PR TITLE
Upgrade to debian bullseye

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:10.7
 
-LABEL maintainer "Dennis Boeckmann <dev@dbck.de>"
-LABEL description "Debian based simple mailtrap container for development purposes"
+LABEL maintainer="Dennis Boeckmann <dev@dbck.de>"
+LABEL description="Debian based simple mailtrap container for development purposes"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -37,6 +37,9 @@ ENV MAILTRAP_MAILBOX_LIMIT 51200000
 ENV MAILTRAP_MESSAGE_LIMIT 10240000
 ENV MAILTRAP_MAX_RECIPIENT_LIMIT 1000
 
+# Avoid kernel logging
+RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
+
 # Postfix
 COPY root/etc/postfix/* /etc/postfix/
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.7
+FROM debian:bullseye-slim
 
 LABEL maintainer="Dennis Boeckmann <dev@dbck.de>"
 LABEL description="Debian based simple mailtrap container for development purposes"
@@ -6,23 +6,20 @@ LABEL description="Debian based simple mailtrap container for development purpos
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
-    && apt-get -q -y install \
-    sudo \
-    vim \
-    wget \
+    && apt-get -q -y --no-install-recommends install \
     curl \
     telnet \
     ssl-cert \
     nginx \
     postfix \
     dovecot-imapd \
-    sqlite \
+    sqlite3 \
     php \
     php-fpm \
     php-mbstring \
     php-sqlite3 \
-    php7.3-imap \
-    php7.3-zip \
+    php-imap \
+    php-zip \
     php-pear \
     roundcube \
     roundcube-sqlite3 \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,25 +8,24 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
     && apt-get -q -y --no-install-recommends install \
     curl \
-    telnet \
-    ssl-cert \
-    nginx \
-    postfix \
     dovecot-imapd \
-    sqlite3 \
+    nginx \
     php \
     php-fpm \
-    php-mbstring \
-    php-sqlite3 \
     php-imap \
-    php-zip \
+    php-mbstring \
     php-pear \
+    php-sqlite3 \
+    php-zip \
+    postfix \
     roundcube \
-    roundcube-sqlite3 \
     roundcube-plugins \
     roundcube-plugins-extra \
+    roundcube-sqlite3 \
     rsyslog \
-    && rm -rf /var/lib/apt/lists/*
+    sqlite3 \
+    ssl-cert \
+    telnet \
 
 ENV MAILTRAP_USER mailtrap
 ENV MAILTRAP_PASSWORD mailtrap

--- a/build/root/docker-entrypoint.sh
+++ b/build/root/docker-entrypoint.sh
@@ -35,8 +35,7 @@ postmap /etc/postfix/transport
 service rsyslog start
 service dovecot start
 service postfix start
-mkdir -p /run/php
-service php7.3-fpm start
+service php7.4-fpm start
 service nginx start
 
 touch /var/log/mail.err && tail -f /var/log/mail.err /var/log/mail.log

--- a/build/root/etc/nginx/sites-available/roundcube
+++ b/build/root/etc/nginx/sites-available/roundcube
@@ -17,7 +17,7 @@ server {
 
     location ~ \.php$ {
         include snippets/fastcgi-php.conf;
-        fastcgi_pass unix:/run/php/php7.3-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.4-fpm.sock;
         fastcgi_read_timeout 300;
     }
 }

--- a/build/root/etc/roundcube/config.inc.php
+++ b/build/root/etc/roundcube/config.inc.php
@@ -1,20 +1,23 @@
 <?php
+
+declare(strict_types=1);
+
 // Looking for the default values set? See: https://github.com/roundcube/roundcubemail/blob/master/config/defaults.inc.php
-$config = array();
-$config['product_name'] = 'MailTrap Roundcube';
-$config['db_dsnw'] = 'sqlite:////var/lib/roundcube/db/sqlite.db';
-$config['des_key'] = '###DES_KEY###';
-$config['plugins'] = array(
-    'archive',
-    'zipdownload',
-    'contextmenu',
-    'keyboard-shortcuts',
-    'message-highlight',
-    'enigma',
-    'emoticons',
-);
-$config['session_lifetime'] = 1440;
-$config['message_show_email'] = true;
-$config['protect_default_folders'] = true;
-//$config['disabled_actions'] = array('addressbook.index','mail.compose','mail.reply','mail.reply-all','mail.forward');
-$config['skin'] = 'larry';
+$config = [
+    'product_name'            => 'MailTrap Roundcube',
+    'db_dsnw'                 => 'sqlite:////var/lib/roundcube/db/sqlite.db',
+    'des_key'                 => '###DES_KEY###',
+    'plugins'                 => [
+        'archive',
+        'zipdownload',
+        'contextmenu',
+        'keyboard-shortcuts',
+        'message-highlight',
+        'enigma',
+        'emoticons',
+    ],
+    'session_lifetime'        => 1440,
+    'message_show_email'      => true,
+    'protect_default_folders' => true,
+    'skin'                    => 'larry',
+];

--- a/build/root/etc/roundcube/config.inc.php
+++ b/build/root/etc/roundcube/config.inc.php
@@ -19,5 +19,5 @@ $config = [
     'session_lifetime'        => 1440,
     'message_show_email'      => true,
     'protect_default_folders' => true,
-    'skin'                    => 'larry',
+    'skin'                    => 'elastic',
 ];


### PR DESCRIPTION
Upgrades the image to the newer Debian Bullseye release.
Also:
* fixes rsyslog kernel log permission denied error
* fixes LABEL typos in `Dockerfile`
* defaults Roundcube skin to `elastic` as it is a more modern UI