### PR TITLE
Add MAILTRAP_DOMAINS to allow not triggering open relay warnings

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,6 +30,38 @@ MAILTRAP_ROUNDCUBE_CONFIG_REQUEST_PATH=""
 MAILTRAP_ROUNDCUBE_NAME="MailTrap Roundcube"
 ```
 
+# Domain Filtering (Optional)
+
+By default, this image accepts mail for any domain (open relay, for development/honeypot use only).
+
+You can restrict accepted recipient domains by setting the `MAILTRAP_ALLOWED_DOMAINS` environment variable. If not set, the server will accept mail for all domains (default behavior).
+
+- To allow a single domain:
+
+```
+docker run -d --rm --init --name=mailtrap \
+  -e MAILTRAP_ALLOWED_DOMAINS=example.com \
+  -p 127.0.0.1:9080:80 -p 127.0.0.1:9025:25 dbck/mailtrap
+```
+
+- To allow multiple domains (comma, semicolon, or space separated):
+
+```
+docker run -d --rm --init --name=mailtrap \
+  -e MAILTRAP_ALLOWED_DOMAINS="example.com,another.com" \
+  -p 127.0.0.1:9080:80 -p 127.0.0.1:9025:25 dbck/mailtrap
+```
+
+or
+
+```
+docker run -d --rm --init --name=mailtrap \
+  -e MAILTRAP_ALLOWED_DOMAINS="example.com another.com" \
+  -p 127.0.0.1:9080:80 -p 127.0.0.1:9025:25 dbck/mailtrap
+```
+
+If a message is sent to a domain not in the allowed list, it will be rejected with a standard SMTP relay error ("Relay access denied").
+
 # Starting a container
 
 **Note:** The examples use the flag `--rm` to automatically remove the container instance, when stopped. The flag `--init` is required to speed up the shutdown of the container. Also the ports are bound to localhost.

--- a/build/root/docker-entrypoint.sh
+++ b/build/root/docker-entrypoint.sh
@@ -44,6 +44,20 @@ sed -i "s/###MAILTRAP_MAILBOX_LIMIT###/$MAILTRAP_MAILBOX_LIMIT/" /etc/postfix/ma
 sed -i "s/###MAILTRAP_MESSAGE_LIMIT###/$MAILTRAP_MESSAGE_LIMIT/" /etc/postfix/main.cf
 sed -i "s/###MAILTRAP_MAX_RECIPIENT_LIMIT###/$MAILTRAP_MAX_RECIPIENT_LIMIT/" /etc/postfix/main.cf
 
+# Set allowed domains restriction if MAILTRAP_ALLOWED_DOMAINS is set
+if [ -n "$MAILTRAP_ALLOWED_DOMAINS" ]; then
+  # Support comma, semicolon, or space as delimiters
+  ALLOWED_DOMAINS=$(echo "$MAILTRAP_ALLOWED_DOMAINS" | tr ',;' '  ')
+  echo "# Auto-generated allowed domains map" > /etc/postfix/allowed_domains
+  for domain in $ALLOWED_DOMAINS; do
+    echo "$domain OK" >> /etc/postfix/allowed_domains
+  done
+  postmap /etc/postfix/allowed_domains
+  sed -i "s|###MAILTRAP_ALLOWED_DOMAINS_RESTRICTION###|check_recipient_access hash:/etc/postfix/allowed_domains|" /etc/postfix/main.cf
+else
+  sed -i "s|###MAILTRAP_ALLOWED_DOMAINS_RESTRICTION###||" /etc/postfix/main.cf
+fi
+
 # Configure services and transports in master.cf
 sed -i "s/#submission inet n       -       y       -       -       smtpd/submission inet n       -       y       -       -       smtpd/" /etc/postfix/master.cf
 echo -e "dovecot unix - n n - - pipe flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -f \${sender} -d ${MAILTRAP_USER}" >> /etc/postfix/master.cf

--- a/build/root/etc/postfix/main.cf
+++ b/build/root/etc/postfix/main.cf
@@ -21,7 +21,7 @@ tls_random_prng_update_period = 3600s
 broken_sasl_auth_clients = yes
 
 smtpd_recipient_limit = ###MAILTRAP_MAX_RECIPIENT_LIMIT###
-smtpd_recipient_restrictions = permit_mynetworks defer_unauth_destination permit
+smtpd_recipient_restrictions = permit_mynetworks ###MAILTRAP_ALLOWED_DOMAINS_RESTRICTION### defer_unauth_destination permit
 
 smtpd_sasl_type = dovecot
 smtpd_sasl_auth_enable = yes


### PR DESCRIPTION
Adding MAILTRAP_DOMAINS setting which allows Mailtrap to be filtered only to a set of domains of interest. This helps support honeypot projects where only a few domains are being researched. Adding this setting prevents spammers from seeing the site as a potential 'open relay'. Backwards compatibility (allow all domains) is maintained by not setting this variable. 